### PR TITLE
Temporary hydration fix

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,4 +1,4 @@
 import {RemixBrowser} from '@remix-run/react';
 import {hydrateRoot} from 'react-dom/client';
 
-hydrateRoot(document, <RemixBrowser />);
+hydrateRoot(document.getElementById('root')!, <RemixBrowser />);

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,18 @@
 import type {EntryContext} from '@shopify/remix-oxygen';
 import {RemixServer} from '@remix-run/react';
 import {renderToReadableStream} from 'react-dom/server';
+import {renderHeadToString} from 'remix-island';
+import {Head} from './root';
+
+const readableString = (value: string) => {
+  const te = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(te.encode(value));
+      controller.close();
+    },
+  });
+};
 
 export default async function handleRequest(
   request: Request,
@@ -8,13 +20,28 @@ export default async function handleRequest(
   responseHeaders: Headers,
   remixContext: EntryContext,
 ) {
+  const {readable, writable} = new TransformStream();
+  const head = readableString(
+    `<!DOCTYPE html><html><head>${renderHeadToString({
+      request,
+      remixContext,
+      Head,
+    })}</head><body><div id="root">`,
+  );
+  const end = readableString(`</div></body></html>`);
+
   const body = await renderToReadableStream(
     <RemixServer context={remixContext} url={request.url} />,
   );
 
+  Promise.resolve()
+    .then(() => head.pipeTo(writable, {preventClose: true}))
+    .then(() => body.pipeTo(writable, {preventClose: true}))
+    .then(() => end.pipeTo(writable));
+
   responseHeaders.set('Content-Type', 'text/html');
 
-  return new Response(body, {
+  return new Response(readable, {
     status: responseStatusCode,
     headers: responseHeaders,
   });

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -14,6 +14,7 @@ import {
 import type {Shop} from '@shopify/hydrogen/storefront-api-types';
 import styles from './styles/app.css';
 import favicon from '../public/favicon.svg';
+import {createHead} from 'remix-island';
 
 export const links: LinksFunction = () => {
   return [
@@ -40,17 +41,21 @@ export async function loader({context}: LoaderArgs) {
   return {layout};
 }
 
+export const Head = createHead(() => (
+  <>
+    <Meta />
+    <Links />
+  </>
+));
+
 export default function App() {
   const data = useLoaderData<typeof loader>();
 
   const {name} = data.layout.shop;
 
   return (
-    <html lang="en">
-      <head>
-        <Meta />
-        <Links />
-      </head>
+    <>
+      <Head />
       <body>
         <h1>Hello, {name}</h1>
         <p>This is a custom storefront powered by Hydrogen</p>
@@ -58,7 +63,7 @@ export default function App() {
         <ScrollRestoration />
         <Scripts />
       </body>
-    </html>
+    </>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "remix-island": "^0.1.2"
       },
       "devDependencies": {
         "@remix-run/dev": "1.12.0",
@@ -13184,6 +13185,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remix-island": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/remix-island/-/remix-island-0.1.2.tgz",
+      "integrity": "sha512-1vXF56y7ZKb8caUduCKdkbxObAxZnTO+arQ94QlwKK6a7wVozGCfiOOk3lr919rm7cy54eeqOVI0hud3cfHlLg==",
+      "peerDependencies": {
+        "@remix-run/react": ">= 1",
+        "@remix-run/server-runtime": ">= 1",
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/require-from-string": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "remix-island": "^0.1.2"
   },
   "devDependencies": {
     "@remix-run/dev": "1.12.0",


### PR DESCRIPTION
This is a temporary fix to alleviate the hydration problems caused by client-side DOM manipulation by 3rd party scripts / extensions that can cause Styled Components to fail on React 18.2 flavors of Remix.

Based on [@kiliman's](https://github.com/kiliman) [initial fix](https://github.com/remix-run/remix/discussions/5244#discussioncomment-4832036), wrapped into [remix-island](https://github.com/Xiphe/remix-island) by [@Xiphe](https://github.com/Xiphe) and [adapted for readableStreams](https://github.com/remix-run/remix/discussions/5244#discussioncomment-4890083) by [@clgeoio](https://github.com/clgeoio)

More information:
- https://github.com/remix-run/remix/issues/5569
- https://github.com/remix-run/remix/discussions/5244
- [Remix Roadmap Discussion](https://www.youtube.com/live/tdVFZidXGZo?feature=share&t=2972)
- https://github.com/facebook/react/issues/24430